### PR TITLE
Add caching for template discovery

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -10,6 +10,10 @@ services:
         tags:
             - { name: doctrine.event_listener, event: postPersist, connection: default }
             - { name: doctrine.event_listener, event: postRemove, connection: default }
+    DigipolisGent\Domainator9k\CoreBundle\EventListener\TokenEventListener:
+        tags:
+            - { name: doctrine.event_listener, event: postPersist, connection: default }
+            - { name: doctrine.event_listener, event: postRemove, connection: default }
     DigipolisGent\Domainator9k\CoreBundle\Service\TemplateService:
         arguments:
             $templateProviders: !tagged template_provider

--- a/src/EventListener/TokentEventListener.php
+++ b/src/EventListener/TokentEventListener.php
@@ -1,0 +1,44 @@
+<?php
+
+
+namespace DigipolisGent\Domainator9k\CoreBundle\EventListener;
+
+use DigipolisGent\Domainator9k\CoreBundle\Entity\Token;
+use DigipolisGent\Domainator9k\CoreBundle\Twig\TemplateHelpExtension;
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+/**
+ * Class TokenEventListener
+ * @package DigipolisGent\Domainator9k\CoreBundle\EventListener
+ */
+class TokenEventListener
+{
+
+    public function __construct(protected TagAwareCacheInterface $cache)
+    {
+    }
+
+    /**
+     * @param LifecycleEventArgs $args
+     */
+    public function postPersist(LifecycleEventArgs $args)
+    {
+        $this->invalidateTemplateCache($args->getObject());
+    }
+
+    /**
+     * @param LifecycleEventArgs $args
+     */
+    public function postRemove(LifecycleEventArgs $args)
+    {
+        $this->invalidateTemplateCache($args->getObject());
+    }
+
+    protected function invalidateTemplateCache($entity)
+    {
+        if ($entity instanceof Token) {
+            $this->cache->invalidateTags([TemplateHelpExtension::CACHE_TAG]);
+        }
+    }
+}

--- a/src/Twig/TemplateHelpExtension.php
+++ b/src/Twig/TemplateHelpExtension.php
@@ -4,6 +4,8 @@ namespace DigipolisGent\Domainator9k\CoreBundle\Twig;
 
 use DigipolisGent\Domainator9k\CoreBundle\Entity\TemplateInterface;
 use DigipolisGent\Domainator9k\CoreBundle\Service\TokenService;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
 use Twig\Environment;
 use Twig\Error\RuntimeError;
 use Twig\Extension\AbstractExtension;
@@ -12,11 +14,15 @@ use Twig\TwigFunction;
 class TemplateHelpExtension extends AbstractExtension
 {
 
+    const CACHE_LIFETIME = 60 * 60 * 24 * 7;
+    const CACHE_TAG = 'template_help';
     protected $tokenService;
+    protected TagAwareCacheInterface $cache;
 
-    public function __construct(TokenService $tokenService)
+    public function __construct(TokenService $tokenService, TagAwareCacheInterface $cache)
     {
         $this->tokenService = $tokenService;
+        $this->cache = $cache;
     }
 
     public function getFunctions(): array
@@ -38,9 +44,8 @@ class TemplateHelpExtension extends AbstractExtension
         ];
     }
 
-    public function templateHelp(Environment $environment, array $classes, $textarea)
+    public function templateHelp(Environment $environment, array $classes, string $textareaSelector)
     {
-
         $templates = [
             'token' => array_keys($this->tokenService->getTemplateReplacements()),
         ];
@@ -48,15 +53,21 @@ class TemplateHelpExtension extends AbstractExtension
             if (!is_a($class, TemplateInterface::class, true)) {
                 new RuntimeError(sprintf('Class %s does not implement %s.', $class, TemplateInterface::class));
             }
-            $templates[$key] = array_keys(call_user_func([$class, 'getTemplateReplacements']));
+            $templates[$key] = $this->cache->get('template_help:' . $class, function(ItemInterface $item) use ($class): array {
+                $item->tag(static::CACHE_TAG);
+                $item->expiresAfter(static::CACHE_LIFETIME);
+
+                return array_keys(call_user_func([$class, 'getTemplateReplacements']));
+            });
         }
 
         return $environment->render(
             '@DigipolisGentDomainator9kCore/Template/templatehelper.twig',
             [
                 'templates' => $templates,
-                'textarea' => $textarea,
+                'textarea' => $textareaSelector,
             ]
         );
     }
+
 }


### PR DESCRIPTION
Page loads for application environment edit forms took _several_ seconds. After investigation it was due to the template discovery that we did to give the end user the option to insert the templates using a dialog.

We added the cache to the template discovery and used cache tags to tag them with the `template_help` cache tag. This way we can invalidate them when a new token is added or one is removed.